### PR TITLE
bunch of bug fixes, and some style changes which hopefully are reasonable.

### DIFF
--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -40,7 +40,8 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     logging.info('Could not set syslog logging handler')
 
 
-  #urllib2.install_opener(urllib2.build_opener(urllib2.HTTPHandler(debuglevel=1)))
+  if debug:
+    urllib2.install_opener(urllib2.build_opener(urllib2.HTTPHandler(debuglevel=1)))
 
 
   def search(url, params):

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -168,7 +168,7 @@ def main():
   dest_dir = options.dest_dir
   debug = options.debug
 
-  grafana_dashboard_backups(elastic_host, elastic_port, dest_dir)
+  grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug)
 
 if __name__ == '__main__':
   main()

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -50,7 +50,7 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
       response = urllib2.urlopen(search_url, timeout=5)
     except urllib2.URLError as e:
       if debug:
-        logger.critical('Failed accessing: %s %s\n' % (search_url, e.read()))
+        logger.critical('Failed accessing: %s' % search_url)
       logger.critical(e)
       sys.exit(1)
 
@@ -69,6 +69,11 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     s1 = re.sub('([^._])([A-Z][a-z]+)', r'\1_\2', name.replace(' ',''))
     s1 = s1.replace('.','_')
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+  def json_dump(data,filename):
+    dump_file = codecs.open(filename, 'w', 'utf-8')
+    json.dump(data, dump_file, sort_keys = True, indent = 2, ensure_ascii=False)
+    dump_file.close()
   
   # Conveniance vars
   es_index_name  = 'grafana-dash'
@@ -82,7 +87,7 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
   formatted_time = utc_datetime.strftime("%Y-%m-%d-%H%MZ")
   
   if debug:
-    logger.info('Grabbing grafana dashboards from: %s \n' % dashboards_url)
+    logger.info('Grabbing grafana dashboards from: %s' % dashboards_url)
 
   scroll_id = scan()['_scroll_id']
 
@@ -104,19 +109,25 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
 
     try:
       for hit in data['hits']['hits']:
-        dashboard_definition = json.loads(hit['_source']['dashboard'])
-        dashboard_file_name  = cam_case_convert(hit['_id']) + '_' + formatted_time + '.json'
+        source               = hit['_source']
+        did                  = hit['_id']
+        dashboard_definition = json.loads(source['dashboard'])
+        dashboard_base_name  = cam_case_convert(did)
+
+        dashboard_file_name  = '%s.json' % dashboard_base_name
         dashboard_file_path  = os.path.join(work_tmp_dir, dashboard_file_name)
-        dashboard_file       = codecs.open(dashboard_file_path, 'w', 'utf-8')
-        json.dump(
-          dashboard_definition,
-          dashboard_file,
-          sort_keys = True,
-          indent = 2,
-          ensure_ascii=False)
-        dashboard_file.close()
+
+        json_dump(dashboard_definition, dashboard_file_path)
         tar.add(dashboard_file_path, '%s/%s' % (es_index_name, dashboard_file_name))
-        logger.info('Added %s to the dashboards backup tarball' % hit['_id'])
+
+        metadata_file_name = '%s.metadata.json' % dashboard_base_name
+        metadata_file_path = os.path.join(work_tmp_dir, metadata_file_name)
+        source['dashboard'] = 'stored in alternate file %s' % dashboard_file_name
+        json_dump(hit, metadata_file_path)
+        tar.add(metadata_file_path, '%s/%s' % (es_index_name, metadata_file_name))
+
+        logger.info('Added %s to the dashboards backup tarball' % did)
+
     except Exception as e:
       logging.critical(e)
       sys.exit(1)

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -16,7 +16,7 @@ import urllib
 import urllib2
 
 
-def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False):
+def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, es_index_name, debug):
   '''Saves all Grafana dashboards stored in Elasticsearch in a tarball
   
      Uses Elasticsearch API to get all saved dashboards into a tarball, the 
@@ -76,7 +76,6 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     dump_file.close()
   
   # Conveniance vars
-  es_index_name  = 'grafana-dash'
   es_type        = 'dashboard'
   es_url         = 'http://%s:%s' % (elastic_host, elastic_port)
   dashboards_url = '%s/%s/%s/_search' % (es_url, es_index_name, es_type)
@@ -93,9 +92,9 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
 
   # Create a tarball with all the dashboards and move to target dir
   
-  tarball = os.path.join(work_tmp_dir, 'grafana_dashboards_backup_' +
-      formatted_time + '.tar.gz')
-  tar = tarfile.open(tarball, 'w:gz')
+  tarball_name = '%s.%s.tar.gz' % (es_index_name, formatted_time)
+  tarball      = os.path.join(work_tmp_dir, tarball_name)
+  tar          = tarfile.open(tarball, 'w:gz')
 
   if not scroll_id:
     raise Exception('Failed to get scroll id')
@@ -134,8 +133,7 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
   
   try:
     tar.close()
-    tarball_file = os.path.basename(tarball)
-    tarball_dest = os.path.join(dest_dir, tarball_file)
+    tarball_dest = os.path.join(dest_dir, tarball_name)
     os.rename(tarball,tarball_dest)
     logger.info('New grafana dashboards backup at %s' % tarball_dest)
   except Exception as e:
@@ -175,6 +173,12 @@ def main():
     dest    = 'dest_dir',
     help    = 'The destination directory where dashboards will be saved',
     metavar = 'DEST_DIR')
+
+  parser.add_option('-i', '--index-name',
+    default = 'grafana-dash',
+    dest    = 'es_index_name',
+    help    = 'the elasticsearch index that contains the dashboards',
+    metavar = 'ELASTICSEARCH_INDEX')
   
   (options, args) = parser.parse_args()
   
@@ -186,7 +190,7 @@ def main():
   dest_dir = options.dest_dir
   debug = options.debug
 
-  grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug)
+  grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, options.es_index_name, debug)
 
 if __name__ == '__main__':
   main()

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -71,8 +71,10 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
   
   # Conveniance vars
+  es_index_name  = 'grafana-dash'
+  es_type        = 'dashboard'
   es_url         = 'http://%s:%s' % (elastic_host, elastic_port)
-  dashboards_url = '%s/%s' % (es_url, 'grafana-dash/dashboard/_search')
+  dashboards_url = '%s/%s/%s/_search' % (es_url, es_index_name, es_type)
   scroll_url     = '%s/_search/scroll' % es_url
   scroll_time    = '1m'
   work_tmp_dir   = tempfile.mkdtemp()
@@ -103,14 +105,18 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     try:
       for hit in data['hits']['hits']:
         dashboard_definition = json.loads(hit['_source']['dashboard'])
-        dashboard_file_name = os.path.join(work_tmp_dir,
-      cam_case_convert(hit['_id']) + '_' + formatted_time + '.json')
-        dashboard_file = codecs.open(dashboard_file_name, 'w', 'utf-8')
-        json.dump(dashboard_definition, dashboard_file, sort_keys = True, indent = 2,
-      ensure_ascii=False)
-        logger.info('Added %s to the dashboards backup tarball' % hit['_id'])
+        dashboard_file_name  = cam_case_convert(hit['_id']) + '_' + formatted_time + '.json'
+        dashboard_file_path  = os.path.join(work_tmp_dir, dashboard_file_name)
+        dashboard_file       = codecs.open(dashboard_file_path, 'w', 'utf-8')
+        json.dump(
+          dashboard_definition,
+          dashboard_file,
+          sort_keys = True,
+          indent = 2,
+          ensure_ascii=False)
         dashboard_file.close()
-        tar.add(dashboard_file_name)
+        tar.add(dashboard_file_path, '%s/%s' % (es_index_name, dashboard_file_name))
+        logger.info('Added %s to the dashboards backup tarball' % hit['_id'])
     except Exception as e:
       logging.critical(e)
       sys.exit(1)

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -12,6 +12,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import urllib
 import urllib2
 
 
@@ -37,6 +38,29 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     logger.addHandler(syslog_handler)
   except Exception:
     logging.info('Could not set syslog logging handler')
+
+
+  #urllib2.install_opener(urllib2.build_opener(urllib2.HTTPHandler(debuglevel=1)))
+
+
+  def search(url, params):
+    search_url = '%s?%s' %  (url, urllib.urlencode(params))
+    try:
+      response = urllib2.urlopen(search_url, timeout=5)
+    except urllib2.URLError as e:
+      if debug:
+        logger.critical('Failed accessing: %s %s\n' % (search_url, e.read()))
+      logger.critical(e)
+      sys.exit(1)
+
+    return json.load(response)
+
+  def scan():
+    return search(dashboards_url, {'search_type': 'scan', 'scroll': scroll_time})
+
+  def scroll(scroll_id):
+    url = '%s/%s' % (scroll_url, scroll_id)
+    return search(url, {'scroll': scroll_time})
   
   def cam_case_convert(name):
     '''strips spaces and replace CamCasing.cam with cam_casing_cam'''
@@ -46,56 +70,52 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
   
   # Conveniance vars
-  dashboards_url = 'http://%s:%s/grafana-dash/dashboard/_search' % (elastic_host,
-  elastic_port)
-  work_tmp_dir = tempfile.mkdtemp()
-  utc_datetime = datetime.datetime.utcnow()
+  es_url         = 'http://%s:%s' % (elastic_host, elastic_port)
+  dashboards_url = '%s/%s' % (es_url, 'grafana-dash/dashboard/_search')
+  scroll_url     = '%s/_search/scroll' % es_url
+  scroll_time    = '1m'
+  work_tmp_dir   = tempfile.mkdtemp()
+  utc_datetime   = datetime.datetime.utcnow()
   formatted_time = utc_datetime.strftime("%Y-%m-%d-%H%MZ")
-  
-  try:
-    elastic_response = urllib2.urlopen(dashboards_url, timeout=5)
-  except urllib2.URLError as e:
-    if debug:
-      logger.critical('Failed accessing: %s \n' % dashboards_url)
-    logger.critical(e)
-    sys.exit(1)
   
   if debug:
     logger.info('Grabbing grafana dashboards from: %s \n' % dashboards_url)
-  
-  try:
-    data = json.load(elastic_response)
-    if debug:
-      print 'Elastic Search raw json:\n'
-      print '-----------------------'
-      print json.dumps(data, sort_keys = False, indent = 4)
-  except Exception as e:
-    logger.critical(e)
-    sys.exit(1)
-  
+
+  scroll_id = scan()['_scroll_id']
+
   # Create a tarball with all the dashboards and move to target dir
   
   tarball = os.path.join(work_tmp_dir, 'grafana_dashboards_backup_' +
       formatted_time + '.tar.gz')
   tar = tarfile.open(tarball, 'w:gz')
+
+  if not scroll_id:
+    raise Exception('Failed to get scroll id')
+
+  while 1:
+    data      = scroll(scroll_id)
+    hit_count = len(data['hits']['hits'])
+    scroll_id = data['_scroll_id']
+    if hit_count == 0:
+      break
+
+    try:
+      for hit in data['hits']['hits']:
+        dashboard_definition = json.loads(hit['_source']['dashboard'])
+        dashboard_file_name = os.path.join(work_tmp_dir,
+      cam_case_convert(hit['_id']) + '_' + formatted_time + '.json')
+        dashboard_file = codecs.open(dashboard_file_name, 'w', 'utf-8')
+        json.dump(dashboard_definition, dashboard_file, sort_keys = True, indent = 2,
+      ensure_ascii=False)
+        logger.info('Added %s to the dashboards backup tarball' % hit['_id'])
+        dashboard_file.close()
+        tar.add(dashboard_file_name)
+    except Exception as e:
+      logging.critical(e)
+      sys.exit(1)
   
   try:
-    for hit in data['hits']['hits']:
-      dashboard_definition = json.loads(hit['_source']['dashboard'])
-      dashboard_file_name = os.path.join(work_tmp_dir,
-    cam_case_convert(hit['_id']) + '_' + formatted_time + '.json')
-      dashboard_file = codecs.open(dashboard_file_name, 'w', 'utf-8')
-      json.dump(dashboard_definition, dashboard_file, sort_keys = True, indent = 2,
-    ensure_ascii=False)
-      logger.info('Added %s to the dashboards backup tarball' % hit['_id'])
-      dashboard_file.close()
-      tar.add(dashboard_file_name)
     tar.close()
-  except Exception as e:
-    logging.critical(e)
-    sys.exit(1)
-  
-  try:
     tarball_file = os.path.basename(tarball)
     tarball_dest = os.path.join(dest_dir, tarball_file)
     os.rename(tarball,tarball_dest)

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -6,6 +6,7 @@ import logging
 import logging.handlers
 import optparse
 import os
+import codecs
 import re
 import shutil
 import sys
@@ -83,7 +84,7 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, debug=False)
       dashboard_definition = json.loads(hit['_source']['dashboard'])
       dashboard_file_name = os.path.join(work_tmp_dir,
     cam_case_convert(hit['_id']) + '_' + formatted_time + '.json')
-      dashboard_file = open(dashboard_file_name, 'w')
+      dashboard_file = codecs.open(dashboard_file_name, 'w', 'utf-8')
       json.dump(dashboard_definition, dashboard_file, sort_keys = True, indent = 2,
     ensure_ascii=False)
       logger.info('Added %s to the dashboards backup tarball' % hit['_id'])


### PR DESCRIPTION

TLDR; handle unicode, fetch entire index, make debug flag work, better filenames in tarballs, 
also backup dashboard metadata, allow passing of index name.


2e1ae83 (fess, 2 hours ago)
   encode dashboard files as utf8

   grafana produces unicode characters in some of it's dashboards, outputing
   unicode buffers to ascii files results in errors of the form:

   CRITICAL:root:'ascii' codec can't encode character u'\xb5' in position 15:
   ordinal not in range(128)

0730807 (fess, 2 hours ago)
   fetch all dashboards not just first 10

   use elasticsearch scan and scroll

   http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html

   previously we only retrieved the default number of results which is 10 scan
   and scroll will pull back all the dashboards

a2c2661 (fess, 2 hours ago)
   make debug option work

   actually pass debug option through

2322e8f (fess, 2 hours ago)
   turn on urllib2 tracing if debug

774f334 (fess, 76 minutes ago)
   don't include tempdirs in tarball

   instead of using the entire path to the temp directory in the tarball use a
   more sensible name based of the index.  ie paths like:
   grafana-dash/dashboard_name.json

f0c963d (fess, 36 minutes ago)
   backup the rest of es results as metadata

   previously we just backed up _source.dashboard which is good for restoring
   a dashboard via the import interface of grafana.

   however if someone wanted to implement a restore direct to ES they would
   need the _id, and the rest of _source.  admittedly title and tags the
   important bits are also in the _source.dashboard there is probably value in
   the user, group and other data grafana may choose to store there.

2bb0271 (fess, 2 minutes ago)
   allow setting of index name

   Allow passing of the index name to backup. Use this name in the output
   tarball. This makes the tool usable to backup kibana dashboards from which
   grafana traces it's roots.
