### PR TITLE
usr/bin/env trick and shutil.move

### DIFF
--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -134,7 +134,7 @@ def grafana_dashboard_backups(elastic_host, elastic_port, dest_dir, es_index_nam
   try:
     tar.close()
     tarball_dest = os.path.join(dest_dir, tarball_name)
-    os.rename(tarball,tarball_dest)
+    shutil.move(tarball,tarball_dest)
     logger.info('New grafana dashboards backup at %s' % tarball_dest)
   except Exception as e:
     logging.critical('Failed to move tarball to %s' % dest_dir)

--- a/grafana-dashboards-backup
+++ b/grafana-dashboards-backup
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#! /usr/bin/env python
 #
 import datetime
 import json


### PR DESCRIPTION
wyatt's changes that were in PR #3 that weren't subsumed in PR #6

a3d8d12 (Wyatt Walter, 9 minutes ago)
   shutil.move instead of os.rename

   os.rename doesn't work across devices, change to shtutil.move

7afaf48 (Wyatt Walter, 12 minutes ago)
   use env trick to find python in path.